### PR TITLE
Fix import error

### DIFF
--- a/delicious_to_evernote.rb
+++ b/delicious_to_evernote.rb
@@ -68,7 +68,7 @@ def parse_a(a)
   raise "'A' tag has unexpected format: #{a.inspect}" if match.nil?
   url = match[1].strip
   add_date = Time.at(match[2].strip.to_i)
-  tags = match[3].strip.split(',').each { |tag| remove_bad_substrings(tag) }
+  tags = match[3].strip.split(',').reject(&:empty?).each { |tag| remove_bad_substrings(tag) }
   title = remove_bad_substrings(match[4].strip)
   raise "title is empty: #{a.inspect}" if title.empty?
   [url, add_date, tags, title]


### PR DESCRIPTION
Evernote for Mac fails importing when the .enex file contains empty `<tag/>` tags.

### Environment

- macOS Sierra 10.12.6
- Evernote.app 6.11.1
- ruby 2.4.0

### Failure case html

```
<A HREF="http://example.com/" ADD_DATE="1484192552" PRIVATE="0" TAGS="ruby,,rails">example</A>
```

### Failure case xml

```
  <note>
    <title>Example</title>
---8<---snip---8<---
    <tag>ruby</tag>
    <tag/>
    <tag>rails</tag>
    <note-attributes>
      <source>web.clip</source>
      <source-url>http://example.com/</source-url>
    </note-attributes>
  </note>
```

### Modified xml by this PR

```
  <note>
    <title>Example</title>
---8<---snip---8<---
    <tag>ruby</tag>
    <tag>rails</tag>
    <note-attributes>
      <source>web.clip</source>
      <source-url>http://example.com/</source-url>
    </note-attributes>
  </note>
```
